### PR TITLE
[FIX]: Tailwind Navigation missing translations

### DIFF
--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -150,4 +150,10 @@
     "Forbidden": "Prohibido",
     "Unauthorized": "Sin autorización",
     "Not Found": "No encontrado",
+    "Pagination Navigation": "Navegación de paginación",
+    "Showing": "Mostrando",
+    "to": "a",
+    "of": "de",
+    "results": "resultados",
+    "Go to page :page": "Ir a la página :page"
 }


### PR DESCRIPTION
## Explicacion:
agregue algunas traducciones de la paginación de tailwindcss. puedes encontrarla en Laravel 8 en la siguiente ruta relativa vendor\laravel\framework\src\Illuminate\Pagination\resources\views\tailwind.blade.php